### PR TITLE
get module instance via module property of Controller

### DIFF
--- a/controllers/DefaultController.php
+++ b/controllers/DefaultController.php
@@ -22,8 +22,8 @@ class DefaultController extends \yii\rest\Controller
     
     public function actionToken()
     {
-        $server = Yii::$app->getModule('oauth2')->getServer();
-        $request = Yii::$app->getModule('oauth2')->getRequest();
+        $server = $this->module->getServer();
+        $request = $this->module->getRequest();
         $response = $server->handleTokenRequest($request);
         
         return $response->getParameters();


### PR DESCRIPTION
replace `Yii::$app->getModule('oauth2')` with `$this->module`

the former has the hard coded module name `oauth2`, which should be avoided.
