### PR TITLE
Fix problem with POST / PUT and add no-cache header

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace filsh\yii2\oauth2server;
+namespace mobilejazz\yii2\oauth2server;
 
 use \Yii;
 

--- a/Module.php
+++ b/Module.php
@@ -40,7 +40,8 @@ class Module extends \yii\base\Module
             $server->addGrantType(new \OAuth2\GrantType\RefreshToken($storages['refresh_token'], [
                 'always_issue_new_refresh_token' => true
             ]));
-            
+			$server->addGrantType(new \OAuth2\GrantType\ClientCredentials($storages['client_credentials']));
+
             $this->_server = $server;
         }
         return $this->_server;

--- a/Module.php
+++ b/Module.php
@@ -10,7 +10,7 @@ class Module extends \yii\base\Module
     
     public $storageMap = [];
     
-    public $storageDefault = 'filsh\yii2\oauth2server\storage\Pdo';
+    public $storageDefault = 'mobilejazz\yii2\oauth2server\storage\Pdo';
     
     public $modelClasses = [];
     
@@ -129,11 +129,11 @@ class Module extends \yii\base\Module
     protected function getDefaultModelClasses()
     {
         return [
-            'Clients' => 'filsh\yii2\oauth2server\models\OauthClients',
-            'AccessTokens' => 'filsh\yii2\oauth2server\models\OauthAccessTokens',
-            'AuthorizationCodes' => 'filsh\yii2\oauth2server\models\OauthAuthorizationCodes',
-            'RefreshTokens' => 'filsh\yii2\oauth2server\models\OauthRefreshTokens',
-            'Scopes' => 'filsh\yii2\oauth2server\models\OauthScopes',
+            'Clients' => 'mobilejazz\yii2\oauth2server\models\OauthClients',
+            'AccessTokens' => 'mobilejazz\yii2\oauth2server\models\OauthAccessTokens',
+            'AuthorizationCodes' => 'mobilejazz\yii2\oauth2server\models\OauthAuthorizationCodes',
+            'RefreshTokens' => 'mobilejazz\yii2\oauth2server\models\OauthRefreshTokens',
+            'Scopes' => 'mobilejazz\yii2\oauth2server\models\OauthScopes',
         ];
     }
     

--- a/Module.php
+++ b/Module.php
@@ -41,6 +41,7 @@ class Module extends \yii\base\Module
                 'always_issue_new_refresh_token' => true
             ]));
 			$server->addGrantType(new \OAuth2\GrantType\ClientCredentials($storages['client_credentials']));
+            $server->addGrantType(new FacebookAuth($storages['public_key']));
 
             $this->_server = $server;
         }
@@ -78,7 +79,7 @@ class Module extends \yii\base\Module
             'user_credentials',
             'public_key',
             'jwt_bearer',
-            'scope',
+            'scope'
         ];
         foreach($defaults as $name) {
             if(!isset($storages[$name])) {

--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ The preferred way to install this extension is through [composer](http://getcomp
 Either run
 
 ```
-php composer.phar require --prefer-dist filsh/yii2-oauth2-server "*"
+php composer.phar require --prefer-dist mobilejazz/yii2-oauth2-server "*"
 ```
 
 or add
 
 ```json
-"filsh/yii2-oauth2-server": "*"
+"mobilejazz/yii2-oauth2-server": "*"
 ```
 
 to the require section of your composer.json.
@@ -26,7 +26,7 @@ To use this extension,  simply add the following code in your application config
 
 ```php
 'oauth2' => [
-    'class' => 'filsh\yii2\oauth2server\Module',
+    'class' => 'mobilejazz\yii2\oauth2server\Module',
     'options' => [
         'token_param_name' => 'accessToken',
         'access_lifetime' => 3600 * 24
@@ -42,7 +42,7 @@ To use this extension,  simply add the following code in your application config
 The next step your shold run migration
 
 ```php
-yii migrate --migrationPath=@vendor/filsh/yii2-oauth2-server/migrations
+yii migrate --migrationPath=@vendor/mobilejazz/yii2-oauth2-server/migrations
 ```
 
 this migration create the oauth2 database scheme and insert test user credentials ```testclient:testpass``` for ```http://fake/```

--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ To use this extension,  simply add the behaviors for your base controller:
 use yii\helpers\ArrayHelper;
 use yii\filters\auth\HttpBearerAuth;
 use yii\filters\auth\QueryParamAuth;
-use filsh\yii2\oauth2server\filters\ErrorToExceptionFilter;
-use filsh\yii2\oauth2server\filters\auth\CompositeAuth;
+use mobilejazz\yii2\oauth2server\filters\ErrorToExceptionFilter;
+use mobilejazz\yii2\oauth2server\filters\auth\CompositeAuth;
 
 class Controller extends \yii\rest\Controller
 {

--- a/composer.json
+++ b/composer.json
@@ -1,18 +1,18 @@
 {
-    "name": "filsh/yii2-oauth2-server",
+    "name": "mobilejazz/yii2-oauth2-server",
     "description": "OAuth2 Server for PHP",
     "keywords": ["yii", "extension", "widget"],
-    "homepage": "https://github.com/filsh/yii2-oauth2-server",
+    "homepage": "https://github.com/mobilejazz/yii2-oauth2-server",
     "type": "yii2-extension",
     "license": "MIT",
     "support": {
-        "email": "imaliy.filsh@gmail.com",
-        "source": "https://github.com/filsh/yii2-oauth2-server"
+        "email": "imaliy.mobilejazz@gmail.com",
+        "source": "https://github.com/mobilejazz/yii2-oauth2-server"
     },
     "authors": [
         {
             "name": "Igor Maliy",
-            "email": "imaliy.filsh@gmail.com"
+            "email": "imaliy.mobilejazz@gmail.com"
         }
     ],
     "require": {
@@ -21,7 +21,7 @@
     },
     "autoload": {
         "psr-4": {
-            "filsh\\yii2\\oauth2server\\": ""
+            "mobilejazz\\yii2\\oauth2server\\": ""
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -6,13 +6,17 @@
     "type": "yii2-extension",
     "license": "MIT",
     "support": {
-        "email": "imaliy.mobilejazz@gmail.com",
+        "email": "mtorruella@mobilejazz.com",
         "source": "https://github.com/mobilejazz/yii2-oauth2-server"
     },
     "authors": [
         {
             "name": "Igor Maliy",
-            "email": "imaliy.mobilejazz@gmail.com"
+            "email": "imaliy.filsh@gmail.com"
+        },
+        {
+            "name": "MobileJazz",
+            "email": "mtorruella@mobilejazz.com"
         }
     ],
     "require": {
@@ -23,5 +27,6 @@
         "psr-4": {
             "mobilejazz\\yii2\\oauth2server\\": ""
         }
-    }
+    },
+    "version":"1.0.3"
 }

--- a/controllers/DefaultController.php
+++ b/controllers/DefaultController.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace filsh\yii2\oauth2server\controllers;
+namespace mobilejazz\yii2\oauth2server\controllers;
 
 use Yii;
 use yii\helpers\ArrayHelper;
-use filsh\yii2\oauth2server\filters\ErrorToExceptionFilter;
+use mobilejazz\yii2\oauth2server\filters\ErrorToExceptionFilter;
 
 class DefaultController extends \yii\rest\Controller
 {

--- a/controllers/DefaultController.php
+++ b/controllers/DefaultController.php
@@ -14,18 +14,23 @@ class DefaultController extends \yii\rest\Controller
     public function behaviors()
     {
         return ArrayHelper::merge(parent::behaviors(), [
-            'exceptionFilter' => [
-                'class' => ErrorToExceptionFilter::className()
-            ],
+									  'exceptionFilter' => [
+										  'class' => ErrorToExceptionFilter::className()
+									  ],
         ]);
     }
-    
+
     public function actionToken()
     {
         $server = $this->module->getServer();
         $request = $this->module->getRequest();
         $response = $server->handleTokenRequest($request);
-        
-        return $response->getParameters();
+
+		//Set cache control headers
+		Yii::$app->response->headers['Cache-Control'] = 'no-cache';
+		Yii::$app->response->headers['Pragma'] = 'no-cache';
+
+
+		return $response->getParameters();
     }
 }

--- a/filters/ErrorToExceptionFilter.php
+++ b/filters/ErrorToExceptionFilter.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace filsh\yii2\oauth2server\filters;
+namespace mobilejazz\yii2\oauth2server\filters;
 
 use Yii;
 use yii\base\Controller;

--- a/filters/auth/CompositeAuth.php
+++ b/filters/auth/CompositeAuth.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace filsh\yii2\oauth2server\filters\auth;
+namespace mobilejazz\yii2\oauth2server\filters\auth;
 
 use \Yii;
 

--- a/filters/auth/CompositeAuth.php
+++ b/filters/auth/CompositeAuth.php
@@ -11,10 +11,14 @@ class CompositeAuth extends \yii\filters\auth\CompositeAuth
      */
     public function beforeAction($action)
     {
+        //We call this before calling Yii::$app->getModule('oauth2')->getRequest(); because this method
+        //cleans the request body
+        $body = Yii::$app->getRequest()->getBodyParams();
+
         $oauthServer = Yii::$app->getModule('oauth2')->getServer();
         $oauthRequest = Yii::$app->getModule('oauth2')->getRequest();
         $oauthServer->verifyResourceRequest($oauthRequest);
-        
+
         return parent::beforeAction($action);
     }
 }

--- a/grants/UserAuthCredentials.php
+++ b/grants/UserAuthCredentials.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace filsh\yii2\oauth2server\grants;
+namespace mobilejazz\yii2\oauth2server\grants;
 
 use \OAuth2\Storage\ClientCredentialsInterface;
 use \OAuth2\Storage\UserCredentialsInterface;

--- a/models/OauthAccessTokens.php
+++ b/models/OauthAccessTokens.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace filsh\yii2\oauth2server\models;
+namespace mobilejazz\yii2\oauth2server\models;
 
 use Yii;
 

--- a/models/OauthAuthorizationCodes.php
+++ b/models/OauthAuthorizationCodes.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace filsh\yii2\oauth2server\models;
+namespace mobilejazz\yii2\oauth2server\models;
 
 use Yii;
 

--- a/models/OauthClients.php
+++ b/models/OauthClients.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace filsh\yii2\oauth2server\models;
+namespace mobilejazz\yii2\oauth2server\models;
 
 use Yii;
 

--- a/models/OauthRefreshTokens.php
+++ b/models/OauthRefreshTokens.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace filsh\yii2\oauth2server\models;
+namespace mobilejazz\yii2\oauth2server\models;
 
 use Yii;
 

--- a/models/OauthScopes.php
+++ b/models/OauthScopes.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace filsh\yii2\oauth2server\models;
+namespace mobilejazz\yii2\oauth2server\models;
 
 use Yii;
 

--- a/storage/Pdo.php
+++ b/storage/Pdo.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace filsh\yii2\oauth2server\storage;
+namespace mobilejazz\yii2\oauth2server\storage;
 
 class Pdo extends \OAuth2\Storage\Pdo
 {


### PR DESCRIPTION
This pull request fixes two bugs:

* When doing a POST / PUT to a Rest controller the request body is empty. Looks like a side effect of calling `$oauthServer = Yii::$app->getModule('oauth2')->getServer();`
* The server wasn't using any Cache-Control header, so some clients (in our case Android) was caching the response and not getting a new token when needed.