### PR TITLE
Add the missing constructor so that this can be used with Yii2

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -64,6 +64,12 @@ class Module extends \yii\base\Module
     }
     
     /**
+     * yii\base\Module requires $id in the constructor.
+     */
+    public function __construct() {
+        parent::__construct('oauth2-server-php-Module');
+    }
+    /**
      * Get oauth2 server instance
      * @param type $force
      * @return \OAuth2\Server


### PR DESCRIPTION
yii2\base\Module requires $id to be passed to the constructor, at a minimum.  Without it, this package is not usable in Yii2.
