### PR TITLE
Fix migration for yii 2.0.6

### DIFF
--- a/migrations/m140501_075311_add_oauth2_server.php
+++ b/migrations/m140501_075311_add_oauth2_server.php
@@ -9,11 +9,11 @@ class m140501_075311_add_oauth2_server extends \yii\db\Migration
         return $this->db->driverName === 'mysql' ? $yes : $no;
     }
 
-    public function primaryKey($columns) {
+    public function buildPrimaryKey($columns) {
         return 'PRIMARY KEY (' . $this->db->getQueryBuilder()->buildColumns($columns) . ')';
     }
 
-    public function foreignKey($columns,$refTable,$refColumns,$onDelete = null,$onUpdate = null) {
+    public function buildForeignKey($columns,$refTable,$refColumns,$onDelete = null,$onUpdate = null) {
         $builder = $this->db->getQueryBuilder();
         $sql = ' FOREIGN KEY (' . $builder->buildColumns($columns) . ')'
             . ' REFERENCES ' . $this->db->quoteTableName($refTable)
@@ -46,7 +46,7 @@ class m140501_075311_add_oauth2_server extends \yii\db\Migration
                 'grant_types' => Schema::TYPE_STRING . '(100) NOT NULL',
                 'scope' => Schema::TYPE_STRING . '(2000) DEFAULT NULL',
                 'user_id' => Schema::TYPE_INTEGER . ' DEFAULT NULL',
-                $this->primaryKey('client_id'),
+                $this->buildPrimaryKey('client_id'),
             ], $tableOptions);
 
             $this->createTable('{{%oauth_access_tokens}}', [
@@ -55,8 +55,8 @@ class m140501_075311_add_oauth2_server extends \yii\db\Migration
                 'user_id' => Schema::TYPE_INTEGER . ' DEFAULT NULL',
                 'expires' => Schema::TYPE_TIMESTAMP . " NOT NULL DEFAULT $now $on_update_now",
                 'scope' => Schema::TYPE_STRING . '(2000) DEFAULT NULL',
-                $this->primaryKey('access_token'),
-                $this->foreignKey('client_id','{{%oauth_clients}}','client_id','CASCADE','CASCADE'),
+                $this->buildPrimaryKey('access_token'),
+                $this->buildForeignKey('client_id','{{%oauth_clients}}','client_id','CASCADE','CASCADE'),
             ], $tableOptions);
 
             $this->createTable('{{%oauth_refresh_tokens}}', [
@@ -65,8 +65,8 @@ class m140501_075311_add_oauth2_server extends \yii\db\Migration
                 'user_id' => Schema::TYPE_INTEGER . ' DEFAULT NULL',
                 'expires' => Schema::TYPE_TIMESTAMP . " NOT NULL DEFAULT $now $on_update_now",
                 'scope' => Schema::TYPE_STRING . '(2000) DEFAULT NULL',
-                $this->primaryKey('refresh_token'),
-                $this->foreignKey('client_id','{{%oauth_clients}}','client_id','CASCADE','CASCADE'),
+                $this->buildPrimaryKey('refresh_token'),
+                $this->buildForeignKey('client_id','{{%oauth_clients}}','client_id','CASCADE','CASCADE'),
             ], $tableOptions);
 
             $this->createTable('{{%oauth_authorization_codes}}', [
@@ -76,8 +76,8 @@ class m140501_075311_add_oauth2_server extends \yii\db\Migration
                 'redirect_uri' => Schema::TYPE_STRING . '(1000) NOT NULL',
                 'expires' => Schema::TYPE_TIMESTAMP . " NOT NULL DEFAULT $now $on_update_now",
                 'scope' => Schema::TYPE_STRING . '(2000) DEFAULT NULL',
-                $this->primaryKey('authorization_code'),
-                $this->foreignKey('client_id','{{%oauth_clients}}','client_id','CASCADE','CASCADE'),
+                $this->buildPrimaryKey('authorization_code'),
+                $this->buildForeignKey('client_id','{{%oauth_clients}}','client_id','CASCADE','CASCADE'),
             ], $tableOptions);
 
             $this->createTable('{{%oauth_scopes}}', [
@@ -89,7 +89,7 @@ class m140501_075311_add_oauth2_server extends \yii\db\Migration
                 'client_id' => Schema::TYPE_STRING . '(32) NOT NULL',
                 'subject' => Schema::TYPE_STRING . '(80) DEFAULT NULL',
                 'public_key' => Schema::TYPE_STRING . '(2000) DEFAULT NULL',
-                $this->primaryKey('client_id'),
+                $this->buildPrimaryKey('client_id'),
             ], $tableOptions);
 
             $this->createTable('{{%oauth_users}}', [
@@ -97,7 +97,7 @@ class m140501_075311_add_oauth2_server extends \yii\db\Migration
                 'password' => Schema::TYPE_STRING . '(2000) DEFAULT NULL',
                 'first_name' => Schema::TYPE_STRING . '(255) DEFAULT NULL',
                 'last_name' => Schema::TYPE_STRING . '(255) DEFAULT NULL',
-                $this->primaryKey('username'),
+                $this->buildPrimaryKey('username'),
             ], $tableOptions);
 
             $this->createTable('{{%oauth_public_keys}}', [


### PR DESCRIPTION
Since yii 2.0.6 the Migration class implements the \yii\db\SchemaBuilderTrait, which has a function called primaryKey($length = null) that causes an exception to be thrown when migrating. I renamed the primaryKey() function in this migration class to buildPrimaryKey(), as well as foreignKey() to buildForeignKey() to preserve consistancy.