### PR TITLE
Migration m140501_075311_add_oauth2_server.php throws exception

### DIFF
--- a/migrations/m140501_075311_add_oauth2_server.php
+++ b/migrations/m140501_075311_add_oauth2_server.php
@@ -9,7 +9,7 @@ class m140501_075311_add_oauth2_server extends \yii\db\Migration
         return $this->db->driverName === 'mysql' ? $yes : $no;
     }
 
-    public function buildPrimaryKey($columns) {
+    public function buildPrimaryKey($columns = null) {
         return 'PRIMARY KEY (' . $this->db->getQueryBuilder()->buildColumns($columns) . ')';
     }
 


### PR DESCRIPTION
I was getting the following exception:

```
PHP Strict Warning 'yii\base\ErrorException' with message 'Declaration of m140501_075311_add_oauth2_server::primaryKey() should be compatible with yii\db\Migration::primaryKey($length = NULL)'
```