### PR TITLE
Add 'refresh_token' to oauth_clients.grant_types

### DIFF
--- a/migrations/m140501_075311_add_oauth2_server.php
+++ b/migrations/m140501_075311_add_oauth2_server.php
@@ -109,7 +109,7 @@ class m140501_075311_add_oauth2_server extends \yii\db\Migration
 
             // insert client data
             $this->batchInsert('{{%oauth_clients}}', ['client_id', 'client_secret', 'redirect_uri', 'grant_types'], [
-                ['testclient', 'testpass', 'http://fake/', 'client_credentials authorization_code password implicit'],
+                ['testclient', 'testpass', 'http://fake/', 'client_credentials authorization_code password implicit refresh_token'],
             ]);
 
             $transaction->commit();


### PR DESCRIPTION
Add 'refresh_token' to default value of oauth_clients.grant_types.
Otherwise if I try to use some refresh_token to get access_token I see error message:
"The grant type is unauthorized for this client_id".