### PR TITLE
Add the HTTP headers when parsing a OAuth2 response

### DIFF
--- a/filters/ErrorToExceptionFilter.php
+++ b/filters/ErrorToExceptionFilter.php
@@ -25,6 +25,12 @@ class ErrorToExceptionFilter extends \yii\base\Behavior
     public function afterAction($event)
     {
         $response = Module::getInstance()->getServer()->getResponse();
+        $headers = $response->getHttpHeaders();
+        if (!empty($headers)) {
+            foreach ($headers as $k => $v) {
+                Yii::$app->response->headers[$k] = $v;
+            }
+        }
 
         $isValid = true;
         if($response !== null) {


### PR DESCRIPTION
The ErrorToExceptionFilter does not handle additional HTTP headers that are added to the OAuth2 response.