### PR TITLE
Default Null value has been set for columns argument in setPrimaryKey

### DIFF
--- a/migrations/m140501_075311_add_oauth2_server.php
+++ b/migrations/m140501_075311_add_oauth2_server.php
@@ -9,7 +9,7 @@ class m140501_075311_add_oauth2_server extends \yii\db\Migration
         return $this->db->driverName === 'mysql' ? $yes : $no;
     }
 
-    public function setPrimaryKey($columns) {
+    public function setPrimaryKey($columns = null) {
         return 'PRIMARY KEY (' . $this->db->getQueryBuilder()->buildColumns($columns) . ')';
     }
 


### PR DESCRIPTION
Default Null value has been set for columns argument in setPrimaryKey method of migrations to fix error below while migrating up:

> Declaration of m140501_075311_add_oauth2_server::primaryKey() should be compatible with yii\db\Migration::primaryKey( = NULL)
