### PR TITLE
Migration PHP 7 Compatibility

### DIFF
--- a/migrations/m140501_075311_add_oauth2_server.php
+++ b/migrations/m140501_075311_add_oauth2_server.php
@@ -9,7 +9,7 @@ class m140501_075311_add_oauth2_server extends \yii\db\Migration
         return $this->db->driverName === 'mysql' ? $yes : $no;
     }
 
-    public function setPrimaryKey($columns) {
+    public function primaryKeys($columns) {
         return 'PRIMARY KEY (' . $this->db->getQueryBuilder()->buildColumns($columns) . ')';
     }
 
@@ -46,7 +46,7 @@ class m140501_075311_add_oauth2_server extends \yii\db\Migration
                 'grant_types' => Schema::TYPE_STRING . '(100) NOT NULL',
                 'scope' => Schema::TYPE_STRING . '(2000) DEFAULT NULL',
                 'user_id' => Schema::TYPE_INTEGER . ' DEFAULT NULL',
-                $this->setPrimaryKey('client_id'),
+                $this->primaryKeys('client_id'),
             ], $tableOptions);
 
             $this->createTable('{{%oauth_access_tokens}}', [
@@ -55,7 +55,7 @@ class m140501_075311_add_oauth2_server extends \yii\db\Migration
                 'user_id' => Schema::TYPE_INTEGER . ' DEFAULT NULL',
                 'expires' => Schema::TYPE_TIMESTAMP . " NOT NULL DEFAULT $now $on_update_now",
                 'scope' => Schema::TYPE_STRING . '(2000) DEFAULT NULL',
-                $this->setPrimaryKey('access_token'),
+                $this->primaryKeys('access_token'),
                 $this->foreignKey('client_id','{{%oauth_clients}}','client_id','CASCADE','CASCADE'),
             ], $tableOptions);
 
@@ -65,7 +65,7 @@ class m140501_075311_add_oauth2_server extends \yii\db\Migration
                 'user_id' => Schema::TYPE_INTEGER . ' DEFAULT NULL',
                 'expires' => Schema::TYPE_TIMESTAMP . " NOT NULL DEFAULT $now $on_update_now",
                 'scope' => Schema::TYPE_STRING . '(2000) DEFAULT NULL',
-                $this->setPrimaryKey('refresh_token'),
+                $this->primaryKeys('refresh_token'),
                 $this->foreignKey('client_id','{{%oauth_clients}}','client_id','CASCADE','CASCADE'),
             ], $tableOptions);
 
@@ -76,7 +76,7 @@ class m140501_075311_add_oauth2_server extends \yii\db\Migration
                 'redirect_uri' => Schema::TYPE_STRING . '(1000) NOT NULL',
                 'expires' => Schema::TYPE_TIMESTAMP . " NOT NULL DEFAULT $now $on_update_now",
                 'scope' => Schema::TYPE_STRING . '(2000) DEFAULT NULL',
-                $this->setPrimaryKey('authorization_code'),
+                $this->primaryKeys('authorization_code'),
                 $this->foreignKey('client_id','{{%oauth_clients}}','client_id','CASCADE','CASCADE'),
             ], $tableOptions);
 
@@ -89,7 +89,7 @@ class m140501_075311_add_oauth2_server extends \yii\db\Migration
                 'client_id' => Schema::TYPE_STRING . '(32) NOT NULL',
                 'subject' => Schema::TYPE_STRING . '(80) DEFAULT NULL',
                 'public_key' => Schema::TYPE_STRING . '(2000) DEFAULT NULL',
-                $this->setPrimaryKey('client_id'),
+                $this->primaryKeys('client_id'),
             ], $tableOptions);
 
             $this->createTable('{{%oauth_users}}', [
@@ -97,7 +97,7 @@ class m140501_075311_add_oauth2_server extends \yii\db\Migration
                 'password' => Schema::TYPE_STRING . '(2000) DEFAULT NULL',
                 'first_name' => Schema::TYPE_STRING . '(255) DEFAULT NULL',
                 'last_name' => Schema::TYPE_STRING . '(255) DEFAULT NULL',
-                $this->setPrimaryKey('username'),
+                $this->primaryKeys('username'),
             ], $tableOptions);
 
             $this->createTable('{{%oauth_public_keys}}', [


### PR DESCRIPTION
Fix warning `Declaration of m140501_075311_add_oauth2_server::primaryKey($columns) should be compatible with yii\db\Migration::primaryKey($length = NULL)`